### PR TITLE
Circle feeder to avoid gatling shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ make run LT_EXTRA_ARGS="-Dgatling.simulations.include=**/SimpleRequestSimulation
 
 ## Simple Request Simularion
 
-It's a `Simulation` that downloads a `csv` file from `Graylog` API based on a query and executes the resulting `URI`s requests `shuffled` and `during` a configured time.
+It's a `Simulation` that downloads a `csv` file from `Graylog` API based on a query and executes the resulting `URI`s requests in `circle` and `during` a configured time.
 
 ### Configuration
 

--- a/src/gatling/scala/com/vivareal/search/simulation/SimpleRequestSimulation.scala
+++ b/src/gatling/scala/com/vivareal/search/simulation/SimpleRequestSimulation.scala
@@ -23,7 +23,7 @@ class SimpleRequestSimulation extends Simulation {
   val httpConf = http.baseURL(baseURL)
 
   downloadCSV(config.getString("graylog.query"), uriField, urisFile)
-  val feeder = csv(urisFile).shuffle
+  val feeder = csv(urisFile).circle
 
   val scn = scenario("SimpleRequestSimulation").during(maxDuration seconds) {
     feed(feeder)


### PR DESCRIPTION
Gatling shuts down when the feeder data set ends. So let's use `circle` strategy to avoid this problem.